### PR TITLE
Markdown cleanup and add linkTitles

### DIFF
--- a/website_docs/automatic_instrumentation.md
+++ b/website_docs/automatic_instrumentation.md
@@ -1,15 +1,23 @@
 ---
-Title: Automatic Instrumentation
-Weight: 3
+title: Automatic Instrumentation
+linkTitle: Automatic
+weight: 3
 ---
 
-Automatic instrumentation with Java uses a Java agent JAR that can be attached to any Java 8+ application. It dynamically injects bytecode to capture telemetry from many popular libraries and frameworks. It can be used to capture telemetry data at the "edges" of an app or service, such as inbound requests, outbound HTTP calls, database calls, and so on. To instrument application code in your app or service, use [Manual Instrumentation](../manual_instrumentation)
+Automatic instrumentation with Java uses a Java agent JAR that can be attached
+to any Java 8+ application. It dynamically injects bytecode to capture telemetry
+from many popular libraries and frameworks. It can be used to capture telemetry
+data at the "edges" of an app or service, such as inbound requests, outbound
+HTTP calls, database calls, and so on. To instrument application code in your
+app or service, use [Manual Instrumentation](../manual_instrumentation)
 
 ## Setup
 
-Download the [latest version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/).
+Download the [latest
+version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/).
 
-The JAR file (`opentelemetry-javaagent.jar`) contains the agent and all automatic instrumentation packages.
+The JAR file (`opentelemetry-javaagent.jar`) contains the agent and all
+automatic instrumentation packages.
 
 Place the JAR in your preferred directory and launch it with your app:
 
@@ -22,7 +30,8 @@ java -javaagent:path/to/opentelemetry-javaagent.jar \
 
 The agent is highly configurable.
 
-One option is to pass configuration properties via the `D` flag. In this example a service name and zipkin exporter for traces are configured:
+One option is to pass configuration properties via the `D` flag. In this example
+a service name and zipkin exporter for traces are configured:
 
 ```
 java -javaagent:path/to/opentelemetry-javaagent.jar \
@@ -56,16 +65,23 @@ java -javaagent:path/to/opentelemetry-javaagent.jar \
      -jar myapp.jar
 ```
 
-To see the full range of configuration options, see [Agent Configuration](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md)
+To see the full range of configuration options, see [Agent
+Configuration](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md)
 
 ## Supported libraries, frameworks, application services, and JVMs
 
-Many popular components support automatic instrumentation. See [Supported libraries, frameworks, application services, and JVMs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md) for the full list.
+Many popular components support automatic instrumentation. See [Supported
+libraries, frameworks, application services, and
+JVMs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md)
+for the full list.
 
 ## Troubleshooting
 
-You can pass the `-Dotel.javaagent.debug=true` parameter to the agent to see debug logs. Note that these are quite verbose.
+You can pass the `-Dotel.javaagent.debug=true` parameter to the agent to see
+debug logs. Note that these are quite verbose.
 
 ## Next steps
 
-After you have automatic instrumentation configured for your app or service, you may want to add [Manual Instrumentation](../manual_instrumentation) to collect custom telemetry data.
+After you have automatic instrumentation configured for your app or service, you
+may want to add [Manual Instrumentation](../manual_instrumentation) to collect
+custom telemetry data.

--- a/website_docs/instrumentation_examples.md
+++ b/website_docs/instrumentation_examples.md
@@ -1,5 +1,6 @@
 ---
 title: Instrumentation Examples
+linkTitle: Examples
 weight: 4
 ---
 


### PR DESCRIPTION
@cartermp:

- This PR does a cleanup of the markdown. Mainly, line-wrapping paragraphs (so that git diffs work better), and adding a blank line where appropriate between markdown elements (like a header or code-block and a paragraph).
- There is no change in content
- I've added a `linkTitle` to the instrumentation page that shortens the title (since these pages are already under the **Instrumentation** section of the website docs.

I'd show you a preview if I could, but I can't 😉 

/cc @austinlparker 