### PR TITLE
Various minor cleanup of examples

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'examples/**'
 jobs:
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ running on your local machine.
   - Note: this example requires having docker installed to run the example.
 - [Setting up the Zipkin exporter](zipkin)
   - This module contains a fully-functional example of configuring the OpenTelemetry SDK to use a
-    Jaeger exporter, and send some spans to a zipkin backend using the OpenTelemetry API.
+    Zipkin exporter, and send some spans to a zipkin backend using the OpenTelemetry API.
   - Note: this example requires having docker installed to run the example.
 - [Configuring the Logging Exporters](logging)
   - This module contains a fully-functional example of configuring the OpenTelemetry SDK to use a 

--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -27,7 +27,7 @@ docker run --rm -it --name jaeger\
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample localhost 14250
+java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample http://localhost:14250
 ```
 ## 4 - Open the Jaeger UI
 

--- a/jaeger/build.gradle
+++ b/jaeger/build.gradle
@@ -12,7 +12,4 @@ dependencies {
 
     //alpha module
     implementation "io.opentelemetry:opentelemetry-semconv"
-
-    implementation("io.grpc:grpc-protobuf")
-    implementation("io.grpc:grpc-netty-shaded")
 }

--- a/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
+++ b/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.example.jaeger;
 
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
@@ -26,18 +24,14 @@ class ExampleConfiguration {
   /**
    * Initialize an OpenTelemetry SDK with a Jaeger exporter and a SimpleSpanProcessor.
    *
-   * @param jaegerHost The host of your Jaeger instance.
-   * @param jaegerPort the port of your Jaeger instance.
+   * @param jaegerEndpoint The endpoint of your Jaeger instance.
    * @return A ready-to-use {@link OpenTelemetry} instance.
    */
-  static OpenTelemetry initOpenTelemetry(String jaegerHost, int jaegerPort) {
-    // Create a channel towards Jaeger end point
-    ManagedChannel jaegerChannel =
-        ManagedChannelBuilder.forAddress(jaegerHost, jaegerPort).usePlaintext().build();
+  static OpenTelemetry initOpenTelemetry(String jaegerEndpoint) {
     // Export traces to Jaeger
     JaegerGrpcSpanExporter jaegerExporter =
         JaegerGrpcSpanExporter.builder()
-            .setChannel(jaegerChannel)
+            .setEndpoint(jaegerEndpoint)
             .setTimeout(30, TimeUnit.SECONDS)
             .build();
 

--- a/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
+++ b/jaeger/src/main/java/io/opentelemetry/example/jaeger/JaegerExample.java
@@ -32,16 +32,14 @@ public final class JaegerExample {
 
   public static void main(String[] args) {
     // Parsing the input
-    if (args.length < 2) {
-      System.out.println("Missing [hostname] [port]");
+    if (args.length < 1) {
+      System.out.println("Missing [endpoint]");
       System.exit(1);
     }
-    String jaegerHostName = args[0];
-    int jaegerPort = Integer.parseInt(args[1]);
+    String jaegerEndpoint = args[0];
 
     // it is important to initialize your SDK as early as possible in your application's lifecycle
-    OpenTelemetry openTelemetry =
-        ExampleConfiguration.initOpenTelemetry(jaegerHostName, jaegerPort);
+    OpenTelemetry openTelemetry = ExampleConfiguration.initOpenTelemetry(jaegerEndpoint);
 
     // Start the example
     JaegerExample example = new JaegerExample(openTelemetry);

--- a/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
+++ b/logging/src/main/java/io/opentelemetry/example/logging/ExampleConfiguration.java
@@ -29,7 +29,7 @@ public final class ExampleConfiguration {
     // Create an instance of PeriodicMetricReaderFactory and configure it
     // to export via the logging exporter
     MetricReaderFactory periodicReaderFactory =
-        PeriodicMetricReader.builder(new LoggingMetricExporter())
+        PeriodicMetricReader.builder(LoggingMetricExporter.create())
             .setInterval(Duration.ofMillis(METRIC_EXPORT_INTERVAL_MS))
             .newMetricReaderFactory();
 
@@ -41,8 +41,11 @@ public final class ExampleConfiguration {
     // the logging exporter.
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
-            .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
             .build();
-    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+    return OpenTelemetrySdk.builder()
+        .setMeterProvider(meterProvider)
+        .setTracerProvider(tracerProvider)
+        .buildAndRegisterGlobal();
   }
 }

--- a/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
+++ b/logging/src/main/java/io/opentelemetry/example/logging/LoggingExporterExample.java
@@ -1,6 +1,5 @@
 package io.opentelemetry.example.logging;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.trace.Span;
@@ -18,8 +17,7 @@ public final class LoggingExporterExample {
 
   public LoggingExporterExample(OpenTelemetry openTelemetry) {
     tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
-    counter =
-        GlobalOpenTelemetry.getMeter(INSTRUMENTATION_NAME).counterBuilder("work_done").build();
+    counter = openTelemetry.getMeter(INSTRUMENTATION_NAME).counterBuilder("work_done").build();
   }
 
   public void myWonderfulUseCase() {

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
@@ -3,7 +3,6 @@ package io.opentelemetry.example.metrics;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -24,9 +23,8 @@ import javax.swing.filechooser.FileSystemView;
  */
 public final class DoubleCounterExample {
 
-  private static final OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
   private static final Tracer tracer =
-      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
+      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
   private static final Meter sampleMeter =
       GlobalOpenTelemetry.getMeter("io.opentelemetry.example.metrics");
   private static final File directoryToCountIn =

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/DoubleCounterExample.java
@@ -24,7 +24,7 @@ import javax.swing.filechooser.FileSystemView;
 public final class DoubleCounterExample {
 
   private static final Tracer tracer =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
+      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics");
   private static final Meter sampleMeter =
       GlobalOpenTelemetry.getMeter("io.opentelemetry.example.metrics");
   private static final File directoryToCountIn =

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
@@ -3,7 +3,6 @@ package io.opentelemetry.example.metrics;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -19,9 +18,8 @@ import javax.swing.filechooser.FileSystemView;
 /** Example of using {@link LongCounter} to count searched directories. */
 public final class LongCounterExample {
 
-  private static final OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
   private static final Tracer tracer =
-      openTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
+      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
 
   private static final Meter sampleMeter =
       GlobalOpenTelemetry.getMeter("io.opentelemetry.example.metrics");

--- a/otlp/build.gradle
+++ b/otlp/build.gradle
@@ -14,7 +14,4 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
     implementation("io.opentelemetry:opentelemetry-sdk-metrics")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp-metrics")
-
-    //external dependency for the grpc transport implementation
-    implementation "io.grpc:grpc-netty-shaded"
 }

--- a/otlp/docker/docker-compose.yaml
+++ b/otlp/docker/docker-compose.yaml
@@ -26,8 +26,7 @@ services:
       - "8888:8888"   # Prometheus metrics exposed by the collector
       - "8889:8889"   # Prometheus exporter metrics
       - "13133:13133" # health_check extension
-      - "55678"       # OpenCensus receiver
-      - "55681:55679" # zpages extension
+      - "55679:55679" # zpages extension
       - "4317:4317"   # otlp receiver
     depends_on:
       - jaeger-all-in-one

--- a/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
+++ b/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
@@ -41,7 +41,11 @@ public final class ExampleConfiguration {
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(spanProcessor)
-            .setResource(AutoConfiguredOpenTelemetrySdk.initialize().getResource())
+            .setResource(
+                AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .build()
+                    .getResource())
             .build();
     OpenTelemetrySdk openTelemetrySdk =
         OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();

--- a/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -56,5 +56,7 @@ public final class OtlpExporterExample {
 
     // sleep for a bit to let everything settle
     Thread.sleep(2000);
+
+    System.out.println("Bye");
   }
 }

--- a/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
+++ b/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureSpanProcessorExample.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 /** This example shows how to instantiate different Span Processors. */
 public final class ConfigureSpanProcessorExample {
 
-  private static final LoggingSpanExporter exporter = new LoggingSpanExporter();
+  private static final LoggingSpanExporter exporter = LoggingSpanExporter.create();
   private static final OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
   // Get the Tracer Management interface
   private static final SdkTracerProvider tracerManagement = openTelemetry.getSdkTracerProvider();
@@ -52,16 +52,16 @@ public final class ConfigureSpanProcessorExample {
     // Default span processors require an exporter as parameter. In this example we use the
     // LoggingSpanExporter which prints on the console output the spans.
 
-    // Configure the simple spans processor. This span processor exports span immediately after they
+    // Configure the simple span processor. This span processor exports span immediately after they
     // are ended.
-    SpanProcessor simpleSpansProcessor = SimpleSpanProcessor.create(exporter);
+    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.create(exporter);
     OpenTelemetrySdk.builder()
         .setTracerProvider(
-            SdkTracerProvider.builder().addSpanProcessor(simpleSpansProcessor).build())
+            SdkTracerProvider.builder().addSpanProcessor(simpleSpanProcessor).build())
         .build();
 
-    // Configure the batch spans processor. This span processor exports span in batches.
-    BatchSpanProcessor batchSpansProcessor =
+    // Configure the batch span processor. This span processor exports span in batches.
+    BatchSpanProcessor batchSpanProcessor =
         BatchSpanProcessor.builder(exporter)
             .setMaxExportBatchSize(512) // set the maximum batch size to use
             .setMaxQueueSize(2048) // set the queue size. This must be >= the export batch size
@@ -71,14 +71,13 @@ public final class ConfigureSpanProcessorExample {
             .setScheduleDelay(5, TimeUnit.SECONDS) // set time between two different exports
             .build();
     OpenTelemetrySdk.builder()
-        .setTracerProvider(
-            SdkTracerProvider.builder().addSpanProcessor(batchSpansProcessor).build())
+        .setTracerProvider(SdkTracerProvider.builder().addSpanProcessor(batchSpanProcessor).build())
         .build();
 
     // Configure the composite span processor. A Composite SpanProcessor accepts a list of Span
     // Processors.
     SpanProcessor multiSpanProcessor =
-        SpanProcessor.composite(simpleSpansProcessor, batchSpansProcessor);
+        SpanProcessor.composite(simpleSpanProcessor, batchSpanProcessor);
     OpenTelemetrySdk.builder()
         .setTracerProvider(SdkTracerProvider.builder().addSpanProcessor(multiSpanProcessor).build())
         .build();

--- a/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -34,14 +34,13 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .build())
             .build();
-
     printSpanLimits(openTelemetrySdk);
-    Tracer tracer = openTelemetrySdk.getTracer("ConfigureTraceExample");
 
-    // OpenTelemetry has a maximum of 32 Attributes by default for Spans, Links, and Events.
+    // OpenTelemetry has a maximum of 128 Attributes by default for Spans, Links, and Events.
+    Tracer tracer = openTelemetrySdk.getTracer("ConfigureTraceExample");
     Span multiAttrSpan = tracer.spanBuilder("Example Span Attributes").startSpan();
     multiAttrSpan.setAttribute("Attribute 1", "first attribute value");
     multiAttrSpan.setAttribute("Attribute 2", "second attribute value");
@@ -55,14 +54,14 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .setSpanLimits(newConf)
                     .build())
             .build();
-
     printSpanLimits(openTelemetrySdk);
 
     // If more attributes than allowed by the configuration are set, they are dropped.
+    tracer = openTelemetrySdk.getTracer("ConfigureTraceExample");
     Span singleAttrSpan = tracer.spanBuilder("Example Span Attributes").startSpan();
     singleAttrSpan.setAttribute("Attribute 1", "first attribute value");
     singleAttrSpan.setAttribute("Attribute 2", "second attribute value");
@@ -79,11 +78,10 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .setSampler(Sampler.alwaysOff())
                     .build())
             .build();
-
     printSpanLimits(openTelemetrySdk);
 
     tracer = openTelemetrySdk.getTracer("ConfigureTraceExample");
@@ -95,7 +93,7 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .setSampler(Sampler.alwaysOn())
                     .build())
             .build();
@@ -112,14 +110,13 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .setSampler(traceIdRatioBased)
                     .build())
             .build();
     printSpanLimits(openTelemetrySdk);
 
     tracer = openTelemetrySdk.getTracer("ConfigureTraceExample");
-
     for (int i = 0; i < 10; i++) {
       tracer
           .spanBuilder(String.format("Span %d might be forwarded to all processors", i))
@@ -154,7 +151,7 @@ class ConfigureTraceExample {
         OpenTelemetrySdk.builder()
             .setTracerProvider(
                 SdkTracerProvider.builder()
-                    .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .setSampler(new MySampler())
                     .build())
             .build();

--- a/zipkin/README.md
+++ b/zipkin/README.md
@@ -18,7 +18,7 @@ to instrument a simple application using Zipkin as trace exporter.
 ```shell script
 docker run --rm -it --name zipkin \
   -p 9411:9411 \
-  openzipkin/zipkin:2.21
+  openzipkin/zipkin:latest
 ```
 
 ## 3 - Start the Application

--- a/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
+++ b/zipkin/src/main/java/io/opentelemetry/example/zipkin/ExampleConfiguration.java
@@ -19,17 +19,14 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
  * the OpenTelemetry APIs.
  */
 public final class ExampleConfiguration {
-  // Zipkin API Endpoints for uploading spans
-  private static final String ENDPOINT_V2_SPANS = "/api/v2/spans";
 
   // Name of the service
   private static final String SERVICE_NAME = "myExampleService";
 
   /** Adds a SimpleSpanProcessor initialized with ZipkinSpanExporter to the TracerSdkProvider */
   static OpenTelemetry initializeOpenTelemetry(String ip, int port) {
-    String httpUrl = String.format("http://%s:%s", ip, port);
-    ZipkinSpanExporter zipkinExporter =
-        ZipkinSpanExporter.builder().setEndpoint(httpUrl + ENDPOINT_V2_SPANS).build();
+    String endpoint = String.format("http://%s:%s/api/v2/spans", ip, port);
+    ZipkinSpanExporter zipkinExporter = ZipkinSpanExporter.builder().setEndpoint(endpoint).build();
 
     Resource serviceNameResource =
         Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, SERVICE_NAME));


### PR DESCRIPTION
- Reapply changes from [PR #4041](https://github.com/open-telemetry/opentelemetry-java/pull/4041) which were lost in the port (my bad)
- Fix typo in readme 
- Use `LoggingMetricExporter.create()` instead of deprecated `new LoggingMetricExporter`
- Use `openzipkin/zipkin:latest` image instead of `openzipkin/zipkin:2.21`
- Fix error in `sdk-usage` example causing span limits to not be applied 
- Take advantage of metrics being available in `GlobalOpenTelemetry` to simplify some stuff
- Fix github action so build actually runs