### PR TITLE
Bump examples to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 ext {
-  openTelemetryVersion = "1.10.0"
-  openTelemetryAlphaVersion = "1.10.0-alpha"
+  openTelemetryVersion = "1.10.1"
+  openTelemetryAlphaVersion = "1.10.1-alpha"
 
   grpcVersion = '1.34.1'
   protobufVersion = '3.11.4'


### PR DESCRIPTION
Update to reflect latest [release](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.10.1).