### PR TITLE
Move @Timed annotation to another method

### DIFF
--- a/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Controller.java
+++ b/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Controller.java
@@ -1,6 +1,7 @@
 package io.opentelemetry.example.micrometer;
 
 import io.micrometer.core.annotation.Timed;
+import java.util.Random;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,8 +9,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class Controller {
 
   @GetMapping("/ping")
-  @Timed("ping.time")
-  public String ping() {
+  public String ping() throws InterruptedException {
+    doWork();
     return "pong";
+  }
+
+  @Timed("dowork.time")
+  private void doWork() throws InterruptedException {
+    Thread.sleep(new Random().nextInt(1000));
   }
 }


### PR DESCRIPTION
Was playing around with the micrometer example and realized that adding `@Timed` to the controller method stomps the automatic instrumentation of the controller method that results in metrics named `http.server.requests`.

Moving the annotation to another method. 