### PR TITLE
Fix @Timed annotation for micrometer-shim

### DIFF
--- a/micrometer-shim/build.gradle
+++ b/micrometer-shim/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     //spring modules
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 }

--- a/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Application.java
+++ b/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Application.java
@@ -1,5 +1,6 @@
 package io.opentelemetry.example.micrometer;
 
+import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
@@ -24,6 +25,12 @@ public class Application {
         .setMeterProvider(
             SdkMeterProvider.builder().registerMetricReader(PrometheusHttpServer.create()).build())
         .build();
+  }
+
+  // Enable @Timed annotation
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry registry) {
+    return new TimedAspect(registry);
   }
 
   // Configure OpenTelemetryMeterRegistry bean, overriding default autoconfigured MeterRegistry bean

--- a/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Controller.java
+++ b/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Controller.java
@@ -1,21 +1,17 @@
 package io.opentelemetry.example.micrometer;
 
-import io.micrometer.core.annotation.Timed;
-import java.util.Random;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class Controller {
 
+  @Autowired private Service service;
+
   @GetMapping("/ping")
   public String ping() throws InterruptedException {
-    doWork();
+    service.doWork();
     return "pong";
-  }
-
-  @Timed("dowork.time")
-  private void doWork() throws InterruptedException {
-    Thread.sleep(new Random().nextInt(1000));
   }
 }

--- a/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Service.java
+++ b/micrometer-shim/src/main/java/io/opentelemetry/example/micrometer/Service.java
@@ -1,0 +1,14 @@
+package io.opentelemetry.example.micrometer;
+
+import io.micrometer.core.annotation.Timed;
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Service {
+
+  @Timed("dowork.time")
+  void doWork() throws InterruptedException {
+    Thread.sleep(new Random().nextInt(1000));
+  }
+}


### PR DESCRIPTION
Was doing some investigation into how micrometer-shim works with exemplars and noticed that the `@Timed` annotation on the `micrometer-shim` example didn't work 😬. This fixes it.  