### PR TITLE
Update Dockerfile

### DIFF
--- a/javaagent/Dockerfile
+++ b/javaagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:18-jre
 
 ADD build/libs/opentelemetry-examples-javaagent-*-SNAPSHOT.jar /app.jar
 ADD build/otel/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar


### PR DESCRIPTION
Pre-req suggest java 1.8, but the Dockerfile contains a jre 11 causing an unsupported class version error. hence raising this PR

Exception in thread "main" java.lang.UnsupportedClassVersionError: io/opentelemetry/example/javagent/Application has been compiled by a more recent version of the Java Runtime (class file version 62.0), this version of the Java Runtime only recognizes class file versions up to 55.0