### PR TITLE
Update jaeger example to export over OTLP

### DIFF
--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -1,7 +1,7 @@
 # Jaeger Example
 
 This is a simple example that demonstrates how to use the OpenTelemetry SDK 
-to instrument a simple application using Jaeger as trace exporter. 
+to instrument a simple application and export to a Jaeger backend.
 
 # How to run
 
@@ -19,15 +19,16 @@ to instrument a simple application using Jaeger as trace exporter.
 
 ```shell script
 docker run --rm -it --name jaeger\
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 4317:4317 \
   -p 16686:16686 \
-  -p 14250:14250 \
-  jaegertracing/all-in-one:1.16
+  jaegertracing/all-in-one:1.39
 ```
 
 
 ## 3 - Start the Application
 ```shell script
-java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample http://localhost:14250
+java -cp build/libs/opentelemetry-examples-jaeger-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.jaeger.JaegerExample http://localhost:4317
 ```
 ## 4 - Open the Jaeger UI
 

--- a/jaeger/build.gradle
+++ b/jaeger/build.gradle
@@ -2,13 +2,13 @@ plugins {
     id 'java'
 }
 
-description = 'OpenTelemetry Examples for Jaeger Exporter'
+description = 'OpenTelemetry Examples for Jaeger Backend'
 ext.moduleName = "io.opentelemetry.examples.jaeger"
 
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
-    implementation("io.opentelemetry:opentelemetry-exporter-jaeger")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
     //alpha module
     implementation "io.opentelemetry:opentelemetry-semconv"

--- a/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
+++ b/jaeger/src/main/java/io/opentelemetry/example/jaeger/ExampleConfiguration.java
@@ -7,11 +7,11 @@ package io.opentelemetry.example.jaeger;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.concurrent.TimeUnit;
 
@@ -22,15 +22,16 @@ import java.util.concurrent.TimeUnit;
 class ExampleConfiguration {
 
   /**
-   * Initialize an OpenTelemetry SDK with a Jaeger exporter and a SimpleSpanProcessor.
+   * Initialize an OpenTelemetry SDK with a {@link OtlpGrpcSpanExporter} and a {@link
+   * BatchSpanProcessor}.
    *
    * @param jaegerEndpoint The endpoint of your Jaeger instance.
    * @return A ready-to-use {@link OpenTelemetry} instance.
    */
   static OpenTelemetry initOpenTelemetry(String jaegerEndpoint) {
-    // Export traces to Jaeger
-    JaegerGrpcSpanExporter jaegerExporter =
-        JaegerGrpcSpanExporter.builder()
+    // Export traces to Jaeger over OTLP
+    OtlpGrpcSpanExporter jaegerOtlpExporter =
+        OtlpGrpcSpanExporter.builder()
             .setEndpoint(jaegerEndpoint)
             .setTimeout(30, TimeUnit.SECONDS)
             .build();
@@ -41,7 +42,7 @@ class ExampleConfiguration {
     // Set to process the spans by the Jaeger Exporter
     SdkTracerProvider tracerProvider =
         SdkTracerProvider.builder()
-            .addSpanProcessor(SimpleSpanProcessor.create(jaegerExporter))
+            .addSpanProcessor(BatchSpanProcessor.builder(jaegerOtlpExporter).build())
             .setResource(Resource.getDefault().merge(serviceNameResource))
             .build();
     OpenTelemetrySdk openTelemetry =


### PR DESCRIPTION
Jaeger supports [OTLP](https://www.jaegertracing.io/docs/1.39/deployment/#collector), and there's an [effort](https://github.com/open-telemetry/opentelemetry-specification/pull/2858) to deprecate the jaeger exporter, so it seems appropriate to demonstrate SDK w/ OTLP exporter to Jaeger backend. 