### PR TITLE
Add prometheus exemplar example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
     }
 
     dependencies {
-        implementation platform("io.opentelemetry:opentelemetry-bom-alpha:1.22.0-alpha")
+        implementation platform("io.opentelemetry:opentelemetry-bom-alpha:1.23.0-alpha")
         implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.22.1-alpha")
         implementation platform("io.grpc:grpc-bom:1.52.1")
     }

--- a/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
+++ b/otlp/src/main/java/io/opentelemetry/example/otlp/ExampleConfiguration.java
@@ -59,10 +59,7 @@ public final class ExampleConfiguration {
                     .build())
             .buildAndRegisterGlobal();
 
-    Runtime.getRuntime()
-        .addShutdownHook(new Thread(openTelemetrySdk.getSdkTracerProvider()::shutdown));
-    Runtime.getRuntime()
-        .addShutdownHook(new Thread(openTelemetrySdk.getSdkMeterProvider()::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(openTelemetrySdk::close));
 
     return openTelemetrySdk;
   }

--- a/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
+++ b/otlp/src/main/java/io/opentelemetry/example/otlp/OtlpExporterExample.java
@@ -36,7 +36,7 @@ public final class OtlpExporterExample {
       Span exampleSpan = tracer.spanBuilder("exampleSpan").startSpan();
       try (Scope scope = exampleSpan.makeCurrent()) {
         counter.add(1);
-        exampleSpan.setAttribute("good", "true");
+        exampleSpan.setAttribute("good", true);
         exampleSpan.setAttribute("exampleNumber", i);
         Thread.sleep(100);
       } finally {

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -35,6 +35,10 @@ To view metrics in prometheus, navigate to:
 
 http://localhost:9090/graph?g0.range_input=15m&g0.expr=incoming_messages&g0.tab=0
 
-To view application metrics in prometheus format, navigate to:
+To fetch application metrics in prometheus format, run:
 
-http://localhost:19090/metrics
+curl localhost:19090/metrics
+
+To fetch application metrics in OpenMetrics format, which includes exemplars, run:
+
+curl -H 'Accept: application/openmetrics-text; version=1.0.0; charset=utf-8' localhost:19090/metrics

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -8,6 +8,8 @@ ext.moduleName = "io.opentelemetry.examples.prometheus"
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
+    implementation("io.opentelemetry:opentelemetry-exporter-logging")
+    implementation("io.opentelemetry:opentelemetry-semconv")
 
     //alpha modules
     implementation("io.opentelemetry:opentelemetry-exporter-prometheus")

--- a/prometheus/src/main/java/io/opentelemetry/example/prometheus/ExampleConfiguration.java
+++ b/prometheus/src/main/java/io/opentelemetry/example/prometheus/ExampleConfiguration.java
@@ -5,22 +5,49 @@
 
 package io.opentelemetry.example.prometheus;
 
-import io.opentelemetry.api.metrics.MeterProvider;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 public final class ExampleConfiguration {
 
   /**
-   * Initializes the Meter SDK and configures the prometheus collector with all default settings.
+   * Initializes the OpenTelemetry SDK and configures the prometheus collector with all default
+   * settings.
    *
    * @param prometheusPort the port to open up for scraping.
-   * @return A MeterProvider for use in instrumentation.
+   * @return a ready-to-use {@link OpenTelemetry} instance.
    */
-  static MeterProvider initializeOpenTelemetry(int prometheusPort) {
-    MetricReader prometheusReader = PrometheusHttpServer.builder().setPort(prometheusPort).build();
+  static OpenTelemetry initOpenTelemetry(int prometheusPort) {
+    // Include required service.name resource attribute on all spans and metrics
+    Resource resource =
+        Resource.getDefault()
+            .merge(Resource.builder().put(SERVICE_NAME, "PrometheusExporterExample").build());
 
-    return SdkMeterProvider.builder().registerMetricReader(prometheusReader).build();
+    OpenTelemetrySdk openTelemetrySdk =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .setResource(resource)
+                    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                    .build())
+            .setMeterProvider(
+                SdkMeterProvider.builder()
+                    .setResource(resource)
+                    .registerMetricReader(
+                        PrometheusHttpServer.builder().setPort(prometheusPort).build())
+                    .build())
+            .buildAndRegisterGlobal();
+
+    Runtime.getRuntime().addShutdownHook(new Thread(openTelemetrySdk::close));
+
+    return openTelemetrySdk;
   }
 }


### PR DESCRIPTION
Add an example of using the prometheus exporter to produce prometheus exemplars.

This PR does the following:

* Add tracerprovider initialization with a logging exporter
* Add trace instrumentation, which creates a span each loop
* Use a counter and histogram metric, instead of a gauge for the example.  Instrumentation is taken from the OTLP example.

If I curl the endpoint using OpenMetrics, I can see exemplars

`curl -H 'Accept: application/openmetrics-text; version=1.0.0; charset=utf-8' http://localhost:19090/metrics`

```
# TYPE super_timer histogram
# HELP super_timer
super_timer_count{otel_scope_name="io.opentelemetry.example.prometheus"} 219.0 1676324922.849
super_timer_sum{otel_scope_name="io.opentelemetry.example.prometheus"} 219088.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="0.0"} 0.0 1676324922.849 # {span_id="b68bdb5d2557fe43",trace_id="72f259bbe3a8e9c7bc2885d5ad97e206"} 0.0 1676324922.020
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="5.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="10.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="25.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="50.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="75.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="100.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="250.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="500.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="750.0"} 0.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="1000.0"} 157.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="2500.0"} 219.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="5000.0"} 219.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="7500.0"} 219.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="10000.0"} 219.0 1676324922.849
super_timer_bucket{otel_scope_name="io.opentelemetry.example.prometheus",le="+Inf"} 219.0 1676324922.849
# TYPE example_counter counter
# HELP example_counter
example_counter_total{otel_scope_name="io.opentelemetry.example.prometheus"} 220.0 1676324922.849
```

The associated trace for the exemplar:

```
INFO: 'exampleSpan' : 72f259bbe3a8e9c7bc2885d5ad97e206 b68bdb5d2557fe43 INTERNAL [tracer: io.opentelemetry.example.prometheus:] AttributesMap{data={good=true, exampleNumber=218}, capacity=128, totalAddedValues=2}
```

cc @jsuereth