### PR TITLE
Revert "Fix gradle wrapper update CLA issue (#133)"

### DIFF
--- a/.github/workflows/update-gradle-wrappers-daily.yml
+++ b/.github/workflows/update-gradle-wrappers-daily.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
-        with:
-          repo-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
   workflow-notification:
     needs:


### PR DESCRIPTION
The bot uses a fixed account name: https://github.com/gradle-update/update-gradle-wrapper-action/blob/f6ef81d9b8e038607556c1144ec043805f1a70cc/src/tasks/main.ts#L97C38-L98

I will open a ticket to see about getting that bot account added to EasyCLA bot account list, but would like to merge this and re-generate the PR so I can reference the open (but failing EasyCLA) PR when making that request.